### PR TITLE
Improve streamlit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,19 @@ The processed video will be saved next to the source file with `_amplified` appe
 
 ## Web interface
 
-For an interactive GUI in your browser, run the Streamlit app:
+For an interactive GUI in your browser, run the Streamlit app. Using
+`python -m` ensures the module is launched even if the `streamlit`
+executable is not on your system `PATH`:
 
 ```bash
-streamlit run web_gui.py
+python -m streamlit run web_gui.py
 ```
 
-Upload a video, adjust the parameters in the sidebar, and download the amplified result directly from the page.
+If you prefer, you can also execute the script directly with Python:
+
+```bash
+python web_gui.py
+```
+
+Upload a video, adjust the parameters in the sidebar, and download the
+amplified result directly from the page.

--- a/web_gui.py
+++ b/web_gui.py
@@ -99,3 +99,13 @@ if uploaded and st.button("Process video"):
             )
             st.video(f)
 
+# Allow the script to be run directly with `python web_gui.py`
+if __name__ == "__main__":
+    import sys
+    from streamlit.web import cli as stcli
+
+    # Invoke the Streamlit CLI programmatically so no separate
+    # `streamlit` command needs to be available on the PATH.
+    sys.argv = ["streamlit", "run", sys.argv[0]]
+    sys.exit(stcli.main())
+


### PR DESCRIPTION
## Summary
- clarify how to launch the Streamlit GUI
- allow running `web_gui.py` directly without the `streamlit` command

## Testing
- `python -m py_compile amp_color.py amp_grayscale.py web_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6888d6c5bb948328aa1a053168ae2c05